### PR TITLE
Add properties to set JavaFX and JavaFX Maven plugin version

### DIFF
--- a/javafx-archetype-fxml/README.md
+++ b/javafx-archetype-fxml/README.md
@@ -21,3 +21,23 @@ mvn archetype:generate \
         -DartifactId=artifactId \
         -Dversion=version
 ```
+
+The following properties can be customized while creating the project:
+
+| Property                    | Default Value |
+| --------------------------- | ------------- |
+| javafx-version              | 11.0.2        |
+| javafx-maven-plugin-version | 0.0.1         |
+
+For example:
+
+```
+mvn archetype:generate \
+        -DarchetypeGroupId=org.openjfx \
+        -DarchetypeArtifactId=javafx-archetype-fxml \
+        -DarchetypeVersion=0.0.1 \
+        -DgroupId=groupid \
+        -DartifactId=artifactId \
+        -Dversion=version
+        -Djavafx-version=12-ea+14
+```

--- a/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,6 +5,14 @@
         name="${rootArtifactId}-parent"
         xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <requiredProperties>
+        <requiredProperty key="javafx-version">
+            <defaultValue>11.0.2</defaultValue>
+        </requiredProperty>
+        <requiredProperty key="javafx-maven-plugin-version">
+            <defaultValue>0.0.1</defaultValue>
+        </requiredProperty>
+    </requiredProperties>
     <fileSets>
         <fileSet filtered="true" encoding="UTF-8">
             <directory>src/main/java</directory>

--- a/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,7 +29,7 @@
                 <exclude>module-info.java</exclude>
             </excludes>
         </fileSet>
-        <fileSet filtered="true" encoding="UTF-8">
+        <fileSet filtered="true" packaged="true" encoding="UTF-8">
             <directory>src/main/resources</directory>
             <includes>
                 <include>**/*.fxml</include>

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
@@ -35,14 +35,6 @@
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>${javafx-maven-plugin-version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <mainClass>${package}.App</mainClass>
                 </configuration>

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>${javafx.version}</version>
+            <version>${javafx-version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
@@ -8,8 +8,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <javafx.version>12-ea+13</javafx.version>
-        <javafx.maven.plugin.version>0.0.1</javafx.maven.plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -20,7 +18,7 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>${javafx.version}</version>
+            <version>${javafx-version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -36,7 +34,7 @@
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
-                <version>${javafx.maven.plugin.version}</version>
+                <version>${javafx-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/App.java
@@ -27,8 +27,7 @@ public class App extends Application {
     }
 
     private static Parent loadFXML(String fxml) throws IOException {
-        System.out.println("/" + fxml + ".fxml");
-        FXMLLoader fxmlLoader = new FXMLLoader(com.gluonhq.App.class.getResource("/" + fxml + ".fxml"));
+        FXMLLoader fxmlLoader = new FXMLLoader(App.class.getResource(fxml + ".fxml"));
         return fxmlLoader.load();
     }
 

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/PrimaryController.java
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/PrimaryController.java
@@ -7,6 +7,6 @@ public class PrimaryController {
 
     @FXML
     private void switchToSecondary() throws IOException {
-        com.gluonhq.App.setRoot("secondary");
+        App.setRoot("secondary");
     }
 }

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/SecondaryController.java
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/SecondaryController.java
@@ -7,6 +7,6 @@ public class SecondaryController {
 
     @FXML
     private void switchToPrimary() throws IOException {
-        com.gluonhq.App.setRoot("primary");
+        App.setRoot("primary");
     }
 }

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -1,8 +1,7 @@
 module $package {
-    
     requires javafx.controls;
     requires javafx.fxml;
 
-    exports $package;
     opens $package to javafx.fxml;
+    exports $package;
 }

--- a/javafx-archetype-simple/README.md
+++ b/javafx-archetype-simple/README.md
@@ -20,3 +20,23 @@ mvn archetype:generate \
         -DartifactId=artifactId \
         -Dversion=version
 ```
+
+The following properties can be customized while creating the project:
+
+| Property                    | Default Value |
+| --------------------------- | ------------- |
+| javafx-version              | 11.0.2        |
+| javafx-maven-plugin-version | 0.0.1         |
+
+For example:
+
+```
+mvn archetype:generate \
+        -DarchetypeGroupId=org.openjfx \
+        -DarchetypeArtifactId=javafx-archetype-fxml \
+        -DarchetypeVersion=0.0.1 \
+        -DgroupId=groupid \
+        -DartifactId=artifactId \
+        -Dversion=version
+        -Djavafx-version=12-ea+14
+```

--- a/javafx-archetype-simple/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/javafx-archetype-simple/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,6 +5,14 @@
         name="${rootArtifactId}-parent"
         xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <requiredProperties>
+        <requiredProperty key="javafx-version">
+            <defaultValue>11.0.2</defaultValue>
+        </requiredProperty>
+        <requiredProperty key="javafx-maven-plugin-version">
+            <defaultValue>0.0.1</defaultValue>
+        </requiredProperty>
+    </requiredProperties>
     <fileSets>
         <fileSet filtered="true" encoding="UTF-8">
             <directory>src/main/java</directory>

--- a/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -30,14 +30,6 @@
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>${javafx-maven-plugin-version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <mainClass>${package}.App</mainClass>
                 </configuration>

--- a/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -8,14 +8,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <javafx.version>12-ea+13</javafx.version>
-        <javafx.maven.plugin.version>0.0.1</javafx.maven.plugin.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>${javafx.version}</version>
+            <version>${javafx-version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -31,7 +29,7 @@
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
-                <version>${javafx.maven.plugin.version}</version>
+                <version>${javafx-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/javafx-archetype-simple/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/javafx-archetype-simple/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -1,6 +1,4 @@
 module $package {
-    
     requires javafx.controls;
     exports $package;
-
 }


### PR DESCRIPTION
Move JavaFX and JavaFX maven plugin to archetype metadata. These can now optionally be set while generating a JavaFX project using an archetype.