### PR TITLE
Add debug execution to the created archetypes

### DIFF
--- a/javafx-archetype-fxml/README.md
+++ b/javafx-archetype-fxml/README.md
@@ -16,7 +16,7 @@ Once you have installed the archetype locally, you can use it to create a new pr
 mvn archetype:generate \
         -DarchetypeGroupId=org.openjfx \
         -DarchetypeArtifactId=javafx-archetype-fxml \
-        -DarchetypeVersion=0.0.3 \
+        -DarchetypeVersion=0.0.6 \
         -DgroupId=groupid \
         -DartifactId=artifactId \
         -Dversion=version
@@ -27,7 +27,8 @@ The following properties can be customized while creating the project:
 | Property                    | Default Value |
 | --------------------------- | ------------- |
 | javafx-version              | 13            |
-| javafx-maven-plugin-version | 0.0.3         |
+| javafx-maven-plugin-version | 0.0.4         |
+| add-debug-configuration     | N             |
 
 For example:
 
@@ -35,9 +36,10 @@ For example:
 mvn archetype:generate \
         -DarchetypeGroupId=org.openjfx \
         -DarchetypeArtifactId=javafx-archetype-fxml \
-        -DarchetypeVersion=0.0.3 \
+        -DarchetypeVersion=0.0.6 \
         -DgroupId=groupid \
         -DartifactId=artifactId \
-        -Dversion=version
-        -Djavafx-version=12-ea+14
+        -Dversion=version \
+        -Djavafx-version=12-ea+14 \
+        -Dadd-debug-configuration=Y
 ```

--- a/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/javafx-archetype-fxml/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -12,6 +12,9 @@
         <requiredProperty key="javafx-maven-plugin-version">
             <defaultValue>0.0.4</defaultValue>
         </requiredProperty>
+        <requiredProperty key="add-debug-configuration">
+            <defaultValue>N</defaultValue>
+        </requiredProperty>
     </requiredProperties>
     <fileSets>
         <fileSet filtered="true" encoding="UTF-8">

--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/pom.xml
@@ -48,9 +48,39 @@
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>${javafx-maven-plugin-version}</version>
-                <configuration>
-                    <mainClass>${package}.App</mainClass>
-                </configuration>
+                <executions>
+                    <execution>
+                        <!-- Default configuration for running -->
+                        <!-- Usage: mvn clean javafx:run -->
+                        <id>default-cli</id>
+                        <configuration>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+#if ("Y" == ${add-debug-configuration.toUpperCase()})
+                    <execution>
+                        <!-- Configuration for manual attach debugging -->
+                        <!-- Usage: mvn clean javafx:run@debug -->
+                        <id>debug</id>
+                        <configuration>
+                            <options>
+                                <option>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000</option>
+                            </options>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Configuration for automatic IDE debugging -->
+                        <id>ide-debug</id>
+                        <configuration>
+                            <options>
+                                <option>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</option>
+                            </options>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+#end
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javafx-archetype-simple/README.md
+++ b/javafx-archetype-simple/README.md
@@ -15,7 +15,7 @@ Once you have installed the archetype locally, you can use it to create a new pr
 mvn archetype:generate \
         -DarchetypeGroupId=org.openjfx \
         -DarchetypeArtifactId=javafx-archetype-simple \
-        -DarchetypeVersion=0.0.3 \
+        -DarchetypeVersion=0.0.6 \
         -DgroupId=groupid \
         -DartifactId=artifactId \
         -Dversion=version
@@ -26,7 +26,8 @@ The following properties can be customized while creating the project:
 | Property                    | Default Value |
 | --------------------------- | ------------- |
 | javafx-version              | 13            |
-| javafx-maven-plugin-version | 0.0.3         |
+| javafx-maven-plugin-version | 0.0.4         |
+| add-debug-configuration     | N             |
 
 For example:
 
@@ -34,9 +35,10 @@ For example:
 mvn archetype:generate \
         -DarchetypeGroupId=org.openjfx \
         -DarchetypeArtifactId=javafx-archetype-fxml \
-        -DarchetypeVersion=0.0.3 \
+        -DarchetypeVersion=0.0.6 \
         -DgroupId=groupid \
         -DartifactId=artifactId \
-        -Dversion=version
-        -Djavafx-version=12-ea+14
+        -Dversion=version \
+        -Djavafx-version=12-ea+14 \
+        -Dadd-debug-configuration=Y
 ```

--- a/javafx-archetype-simple/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/javafx-archetype-simple/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -12,6 +12,9 @@
         <requiredProperty key="javafx-maven-plugin-version">
             <defaultValue>0.0.4</defaultValue>
         </requiredProperty>
+        <requiredProperty key="add-debug-configuration">
+            <defaultValue>N</defaultValue>
+        </requiredProperty>
     </requiredProperties>
     <fileSets>
         <fileSet filtered="true" encoding="UTF-8">

--- a/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/javafx-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -43,9 +43,39 @@
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>${javafx-maven-plugin-version}</version>
-                <configuration>
-                    <mainClass>${package}.App</mainClass>
-                </configuration>
+                <executions>
+                    <execution>
+                        <!-- Default configuration for running -->
+                        <!-- Usage: mvn clean javafx:run -->
+                        <id>default-cli</id>
+                        <configuration>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+#if ("Y" == ${add-debug-configuration.toUpperCase()})
+                    <execution>
+                        <!-- Configuration for manual attach debugging -->
+                        <!-- Usage: mvn clean javafx:run@debug -->
+                        <id>debug</id>
+                        <configuration>
+                            <options>
+                                <option>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000</option>
+                            </options>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Configuration for automatic IDE debugging -->
+                        <id>ide-debug</id>
+                        <configuration>
+                            <options>
+                                <option>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</option>
+                            </options>
+                            <mainClass>${package}.App</mainClass>
+                        </configuration>
+                    </execution>
+#end
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This PR is based on @jperedadnr comments at [StackOverflow](https://stackoverflow.com/questions/56197372/i-cant-debug-an-application-using-netbeans-11-with-javafx-12) modified for running debugger from IDE.

It might be better to have two debug executions. One as originally show, and call it "<id>debug</id>" and the one in this PR changing it's name to "<id>ide-debug</id>"

@neilcsmith-net has advocated, in [another issue](https://github.com/apache/netbeans/pull/1983#issuecomment-600158804), for a general solution where archetype/pom can specify common IDE actions. He suggests representatives of maven,IDEs,JavaFX and others work something out.