### PR TITLE
comment out module syntax for JDK8

### DIFF
--- a/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/javafx-archetype-fxml/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+#if ("8" == ${javafx-version} || "1.8" == ${javafx-version})
+/* doesn't work with source level ${javafx-version}:
+#end
 module $package {
     requires javafx.controls;
     requires javafx.fxml;
@@ -5,3 +8,6 @@ module $package {
     opens $package to javafx.fxml;
     exports $package;
 }
+#if ("8" == ${javafx-version} || "1.8" == ${javafx-version})
+*/
+#end

--- a/javafx-archetype-simple/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/javafx-archetype-simple/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -1,4 +1,10 @@
+#if ("8" == ${javafx-version} || "1.8" == ${javafx-version})
+/* doesn't work with source level ${javafx-version}:
+#end
 module $package {
     requires javafx.controls;
     exports $package;
 }
+#if ("8" == ${javafx-version} || "1.8" == ${javafx-version})
+*/
+#end


### PR DESCRIPTION
This comments out the JDK9's module syntax to avoid complaints that `module` keyword can only be used with JDK9+ when running on JDK8 or with target=1.8.